### PR TITLE
Updating the OAuth dependency version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,185 +1,177 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.jama.oslc</groupId>
-  <artifactId>com.jama.oslc.adapter</artifactId>
-  <packaging>war</packaging>
-  <version>1.0-SNAPSHOT</version>
-  <name>Jama OSLC Adapter</name>
-  <url>http://maven.apache.org</url>
-    
-  <repositories>
-    <repository>
-      <id>lyo-releases</id>
-      <name>Eclipse Lyo Releases</name>
-      <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
-      <snapshots><enabled>false</enabled></snapshots>
-    </repository>
-    <repository>
-      <id>lyo-snapshots</id>
-      <name>Eclipse Lyo Snapshots</name>
-      <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
-      <releases><enabled>false</enabled></releases>
-    </repository>
-    
-    <repository>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.jama.oslc</groupId>
+    <artifactId>com.jama.oslc.adapter</artifactId>
+    <packaging>war</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>Jama OSLC Adapter</name>
+    <url>http://maven.apache.org</url>
+
+    <repositories>
+        <repository>
+            <id>lyo-releases</id>
+            <name>Eclipse Lyo Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>lyo-snapshots</id>
+            <name>Eclipse Lyo Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+
+        <repository>
             <id>oauth</id>
             <url>http://oauth.googlecode.com/svn/code/maven</url>
         </repository>
-    
-  </repositories>
-  <dependencies>
-    <dependency>
-        <groupId>javax.json</groupId>
-        <artifactId>javax.json-api</artifactId>
-        <version>1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxrs</artifactId>
-      <version>3.1.3.Final</version>
-      <scope>provided</scope>
-    </dependency> -->
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-client</artifactId>
-      <version>3.0.6.Final</version>
-      <scope>provided</scope>
-    </dependency>
-      <dependency>
-    	<groupId>org.eclipse.lyo.oslc4j.core</groupId>
-    	<artifactId>oslc4j-jena-provider</artifactId>
-    	<version>2.3.1-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.lyo.clients</groupId>
-      <artifactId>oslc-java-client</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
-    </dependency>
-    
-    <!-- dependencies for oauth -->
-     <dependency>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- <dependency>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-jaxrs</artifactId>
+          <version>3.1.3.Final</version>
+          <scope>provided</scope>
+        </dependency> -->
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>3.0.6.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.lyo.oslc4j.core</groupId>
+            <artifactId>oslc4j-jena-provider</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.lyo.clients</groupId>
+            <artifactId>oslc-java-client</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+        <!-- dependencies for oauth -->
+        <dependency>
             <groupId>org.eclipse.lyo.server</groupId>
             <artifactId>oauth-core</artifactId>
-            <version>2.1.0</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lyo.server</groupId>
             <artifactId>oauth-consumer-store</artifactId>
-            <version>2.1.0</version>
+            <version>2.4.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.oauth.core/oauth -->
-<dependency>
-    <groupId>net.oauth.core</groupId>
-    <artifactId>oauth</artifactId>
-    <version>20100527</version>
-</dependency>
+        <dependency>
+            <groupId>net.oauth.core</groupId>
+            <artifactId>oauth</artifactId>
+            <version>20100527</version>
+        </dependency>
 
-       <!-- https://mvnrepository.com/artifact/net.oauth.core/oauth-provider -->
-<dependency>
-    <groupId>net.oauth.core</groupId>
-    <artifactId>oauth-provider</artifactId>
-    <version>20100527</version>
-</dependency>
+        <!-- https://mvnrepository.com/artifact/net.oauth.core/oauth-provider -->
+        <dependency>
+            <groupId>net.oauth.core</groupId>
+            <artifactId>oauth-provider</artifactId>
+            <version>20100527</version>
+        </dependency>
 
-<!-- https://stackoverflow.com/questions/42361563/unable-to-use-wso2-as-identification-server-when-my-application-is-running-in-jb -->
-<!-- 
-<dependency>
-       <groupId>org.wso2.carbon.identity.agent.sso.java</groupId>
-       <artifactId>org.wso2.carbon.identity.sso.agent</artifactId>
-       <version>5.1.3</version>
-</dependency>
--->
+        <!-- https://stackoverflow.com/questions/42361563/unable-to-use-wso2-as-identification-server-when-my-application-is-running-in-jb -->
+        <!--
+        <dependency>
+            <groupId>org.wso2.carbon.identity.agent.sso.java</groupId>
+            <artifactId>org.wso2.carbon.identity.sso.agent</artifactId>
+            <version>5.1.3</version>
+        </dependency>
+        -->
 
+        <!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->
+        <!-- The problem is that javax.json-api only contains the API (interfaces) and no implementation.
+             If your server comes with a pre-bundled implementation this should work, but if not you can add the following dependency to get an implementation
+         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+        -->
 
-    
-    <!-- https://mvnrepository.com/artifact/org.glassfish/javax.json -->
-    
-    <!-- The problem is that javax.json-api only contains the API (interfaces) and no implementation.
+        <!-- https://mvnrepository.com/artifact/org.apache.ws.commons.util/ws-commons-util -->
+        <dependency>
+            <groupId>org.apache.ws.commons.util</groupId>
+            <artifactId>ws-commons-util</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+    </dependencies>
 
-If your server comes with a pre-bundled implementation this should work, but if not you can add the following dependency to get an implementation 
-    
-<dependency>
-    <groupId>org.glassfish</groupId>
-    <artifactId>javax.json</artifactId>
-    <version>1.1.2</version>
-</dependency>
-    -->
-    
-    <!-- https://mvnrepository.com/artifact/org.apache.ws.commons.util/ws-commons-util -->
-<dependency>
-    <groupId>org.apache.ws.commons.util</groupId>
-    <artifactId>ws-commons-util</artifactId>
-    <version>1.0.2</version>
-</dependency>
-    
-    
-  </dependencies>
-  <build>
-    <finalName>jama-oslc-adapter</finalName>
-    <plugins>
-        <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>templating-maven-plugin</artifactId>
-            <version>1.0.0</version>
-            <executions>
-                <execution>
-                    <id>filter-src</id>
-                    <goals><goal>filter-sources</goal></goals>
-                </execution>
-            </executions>
-        </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-war-plugin</artifactId>
-            <version>2.3</version>
-            <configuration>
-                <webResources>
-                    <resource>
-                        <filtering>true</filtering>
-                        <directory>src/main/webapp</directory>
-                    </resource>
-                </webResources>
-            </configuration>
-        </plugin>
-      <plugin>
-          <groupId>org.wildfly.plugins</groupId>
-          <artifactId>wildfly-maven-plugin</artifactId>
-          <version>1.2.0.Alpha4</version>
-          <configuration>
-              <serverArgs>-Djboss.http.port=8080</serverArgs>
-              <name>${project.build.finalName}.war</name>
-          
-          <!-- for debugging -->
-          <!-- 
-          <java-opts>
-                        <java-opt>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8787</java-opt>
-                    </java-opts>
-          -->
-          </configuration>
-          
-          
-         
-          
-          
-          
-          
-      </plugin>
-      <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-          </configuration>
-        </plugin>
+    <build>
+        <finalName>jama-oslc-adapter</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>templating-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>filter-src</id>
+                        <goals>
+                            <goal>filter-sources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <webResources>
+                        <resource>
+                            <filtering>true</filtering>
+                            <directory>src/main/webapp</directory>
+                        </resource>
+                    </webResources>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>1.2.0.Alpha4</version>
+                <configuration>
+                    <serverArgs>-Djboss.http.port=8080</serverArgs>
+                    <name>${project.build.finalName}.war</name>
 
-    </plugins>
-  </build>
+                    <!-- for debugging -->
+                    <!--
+                    <java-opts>
+                                  <java-opt>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8787</java-opt>
+                              </java-opts>
+                    -->
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/com/jama/oslc/client/RootServicesClient.java
+++ b/src/main/java/com/jama/oslc/client/RootServicesClient.java
@@ -48,7 +48,7 @@ public class RootServicesClient {
 			OslcClient rootServicesClient = new OslcClient();
 			ClientResponse response = rootServicesClient.getResource(rootServicesUrl,OSLCConstants.CT_RDF);
 			InputStream is = response.getEntity(InputStream.class);
-			Model  rdfModel = ModelFactory.createDefaultModel();
+			Model rdfModel = ModelFactory.createDefaultModel();
 			rdfModel.read(is, rootServicesUrl);
 
 			//get the catalog URL


### PR DESCRIPTION
Updating the oauth-core and oauth-consumer-store for the lyo dependency to avoid the error thrown in the token request, and avoid to use snapshots versions.